### PR TITLE
Add ability to extend undefined line to the edges with extendEnds

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ Get or set *transitionInitial*, a boolean flag that indicates whether to perform
 
 The default value is `true`.
 
+<a href="#lineChunked_extendEnds" name="lineChunked_extendEnds">#</a> *lineChunked*.**extendEnds**([*[xMin, xMax]*])
+
+Get or set *extendEnds*, an array `[xMin, xMax]` specifying the minimum and maximum x pixel values
+(e.g., `xScale.range()`). If defined, the undefined line will extend to the values provided,
+otherwise it will end at the last defined points.
 
 
 <a href="#lineChunked_lineStyles" name="lineChunked_lineStyles">#</a> *lineChunked*.**lineStyles**([*lineStyles*])

--- a/example/example-gallery.js
+++ b/example/example-gallery.js
@@ -67,7 +67,7 @@ var examples = [
     },
   },
   {
-    label: 'Many points, undefined at ends',
+    label: 'Undefined at ends',
     render: function typicalExample(root) {
       var g = root.append('svg')
         .attr('width', exampleWidth)
@@ -79,6 +79,26 @@ var examples = [
         .x(function (d) { return x(d[0]); })
         .y(function (d) { return x(d[1]); })
         .defined(function (d) { return d[1] !== null; });
+
+      var data = [[0, null], [1, null], [2, 1], [3, 3], [4, 2], [5, 2], [6, 0], [7, 1], [8, 1], [9, null], [10, null]];
+
+      g.datum(data).call(chunked);
+    },
+  },
+  {
+    label: 'Undefined at ends + extendEnds',
+    render: function typicalExample(root) {
+      var g = root.append('svg')
+        .attr('width', exampleWidth)
+        .attr('height', exampleHeight)
+        .append('g');
+
+      var chunked = d3.lineChunked()
+        .lineStyles({ 'stroke-width': '10px' })
+        .x(function (d) { return x(d[0]); })
+        .y(function (d) { return x(d[1]); })
+        .defined(function (d) { return d[1] !== null; })
+        .extendEnds(x.range());
 
       var data = [[0, null], [1, null], [2, 1], [3, 3], [4, 2], [5, 2], [6, 0], [7, 1], [8, 1], [9, null], [10, null]];
 

--- a/src/lineChunked.js
+++ b/src/lineChunked.js
@@ -115,6 +115,14 @@ export default function () {
   let transitionInitial = true;
 
   /**
+   * An array `[xMin, xMax]` specifying the minimum and maximum x pixel values
+   * (e.g., `xScale.range()`). If defined, the undefined line will extend to
+   * the the values provided, otherwise it will end at the last defined points.
+   */
+  let extendEnds;
+
+
+  /**
    * Helper function to compute the contiguous segments of the data
    * @param {Array} lineData the line data
    * @return {Array} An array of segments (subarrays) of the line data
@@ -229,7 +237,8 @@ export default function () {
   /**
    * Render the paths for segments and gaps
    */
-  function renderPaths(initialRender, context, selection, lineData, segments, [xMin, xMax], [yMin, yMax]) {
+  function renderPaths(initialRender, context, selection, lineData, segments,
+      [xMin, xMax], [yMin, yMax]) {
     let definedPath = selection.select('.d3-line-chunked-defined');
     let undefinedPath = selection.select('.d3-line-chunked-undefined');
 
@@ -238,6 +247,10 @@ export default function () {
 
     // main line function
     const line = d3Line().x(x).y(y).curve(curve);
+
+    // can be different if the user decides to extend ends since we need to recreate the data
+    // in a different format.
+    let undefinedLine = line;
 
     // initial render
     if (definedPath.empty()) {
@@ -254,7 +267,23 @@ export default function () {
 
     // update attached data
     definedPath.datum(lineData);
-    undefinedPath.datum(lineData);
+    let undefinedData = lineData;
+
+    // if the user specifies to extend ends for the undefined line, add points to the line for them.
+    if (extendEnds && lineData.length) {
+      // we have to process the data here since we don't know how to format an input object
+      // we use the [x, y] format of a data point
+      const processedLineData = lineData.map(d => [x(d), y(d)]);
+      undefinedData = [
+        [extendEnds[0], processedLineData[0][1]],
+        ...processedLineData,
+        [extendEnds[1], processedLineData[processedLineData.length - 1][1]],
+      ];
+
+      // this line function works on the processed data (default .x and .y read the [x,y] format)
+      undefinedLine = d3Line().curve(curve);
+    }
+    undefinedPath.datum(undefinedData);
     let clipPathRects = clipPath.selectAll('rect').data(segments);
 
     // get stroke width to avoid having the clip rects clip the stroke
@@ -281,11 +310,19 @@ export default function () {
 
       // have the line load in with a flat y value
       let initialLine = line;
+      let initialUndefinedLine = line;
       if (transitionInitial) {
         initialLine = d3Line().x(x).y(yMax).curve(curve);
+
+        // if the user extends ends, we should use the line that works on that data
+        if (extendEnds) {
+          initialUndefinedLine = d3Line().y(yMax).curve(curve);
+        } else {
+          initialUndefinedLine = initialLine;
+        }
       }
       definedPath.attr('d', initialLine);
-      undefinedPath.attr('d', initialLine);
+      undefinedPath.attr('d', initialUndefinedLine);
     }
 
 
@@ -345,21 +382,21 @@ export default function () {
       .attr('y', clipRectY)
       .attr('height', clipRectHeight);
 
-
-    // update the `d` attribute
-    function dTween(d) {
-      const previous = select(this).attr('d');
-      const current = line(d);
-      return interpolatePath(previous, current);
-    }
-
     if (definedPath.attrTween) {
       // use attrTween is available (in transition)
-      definedPath.attrTween('d', dTween);
-      undefinedPath.attrTween('d', dTween);
+      definedPath.attrTween('d', function dTween(d) {
+        const previous = select(this).attr('d');
+        const current = line(d);
+        return interpolatePath(previous, current);
+      });
+      undefinedPath.attrTween('d', function dTween(d) {
+        const previous = select(this).attr('d');
+        const current = undefinedLine(d);
+        return interpolatePath(previous, current);
+      });
     } else {
       definedPath.attr('d', d => line(d));
-      undefinedPath.attr('d', d => line(d));
+      undefinedPath.attr('d', d => undefinedLine(d));
     }
   }
 
@@ -381,7 +418,10 @@ export default function () {
 
     // determine the extent of the y values
     const yExtent = extent(filteredLineData.map(d => y(d)));
-    const xExtent = extent(filteredLineData.map(d => x(d)));
+
+    // determine the extent of the x values to handle stroke-width adjustments on
+    // clipping rects. If extendEnds is provided, use that, otherwise compute it.
+    const xExtent = extendEnds || extent(filteredLineData.map(d => x(d)));
 
     const initialRender = selection.select('.d3-line-chunked-defined').empty();
     renderCircles(initialRender, context, selection, points);
@@ -495,6 +535,13 @@ export default function () {
     get: () => transitionInitial,
     set: (newValue) => { transitionInitial = newValue; },
     setType: 'boolean',
+  });
+
+  // define `extendEnds([extendEnds])`
+  lineChunked.extendEnds = getterSetter({
+    get: () => extendEnds,
+    set: (newValue) => { extendEnds = newValue; },
+    setType: 'object', // should be an array
   });
 
   return lineChunked;

--- a/src/lineChunked.js
+++ b/src/lineChunked.js
@@ -420,8 +420,9 @@ export default function () {
     const yExtent = extent(filteredLineData.map(d => y(d)));
 
     // determine the extent of the x values to handle stroke-width adjustments on
-    // clipping rects. If extendEnds is provided, use that, otherwise compute it.
-    const xExtent = extendEnds || extent(filteredLineData.map(d => x(d)));
+    // clipping rects. Do not use extendEnds here since it can clip the line ending
+    // in an unnatural way, it's better to just show the end.
+    const xExtent = extent(filteredLineData.map(d => x(d)));
 
     const initialRender = selection.select('.d3-line-chunked-defined').empty();
     renderCircles(initialRender, context, selection, points);

--- a/test/lineChunked-test.js
+++ b/test/lineChunked-test.js
@@ -131,8 +131,8 @@ tape('lineChunked() with many data points and some undefined', function (t) {
   g.datum(data).call(chunked);
   // console.log(g.node().innerHTML);
 
-  t.equal(5, lengthOfPath(g.select(definedLineClass)), 5);
-  t.equal(5, lengthOfPath(g.select(undefinedLineClass)), 5);
+  t.equal(5, lengthOfPath(g.select(definedLineClass)));
+  t.equal(5, lengthOfPath(g.select(undefinedLineClass)));
   t.equal(1, g.select(definedPointClass).size());
 
   const rects = g.selectAll('clipPath').selectAll('rect');
@@ -159,8 +159,8 @@ tape('lineChunked() stroke width clipping adjustments', function (t) {
   g.datum(data).call(chunked);
   // console.log(g.node().innerHTML);
 
-  t.equal(5, lengthOfPath(g.select(definedLineClass)), 5);
-  t.equal(5, lengthOfPath(g.select(undefinedLineClass)), 5);
+  t.equal(5, lengthOfPath(g.select(definedLineClass)));
+  t.equal(5, lengthOfPath(g.select(undefinedLineClass)));
   t.equal(1, g.select(definedPointClass).size());
 
   const rects = g.selectAll('clipPath').selectAll('rect');
@@ -186,8 +186,8 @@ tape('lineChunked() when context is a transition', function (t) {
   g.datum(data).transition().duration(0).call(chunked);
   // console.log(g.node().innerHTML);
 
-  t.equal(5, lengthOfPath(g.select(definedLineClass)), 5);
-  t.equal(5, lengthOfPath(g.select(undefinedLineClass)), 5);
+  t.equal(5, lengthOfPath(g.select(definedLineClass)));
+  t.equal(5, lengthOfPath(g.select(undefinedLineClass)));
   t.equal(1, g.select(definedPointClass).size());
 
   const rects = g.selectAll('clipPath').selectAll('rect');
@@ -224,6 +224,41 @@ tape('lineChunked() - defined and isNext can set gaps in data', function (t) {
   const rectsDefined = gDefined.selectAll('clipPath').node().innerHTML;
   const rectsIsNext = gIsNext.selectAll('clipPath').node().innerHTML;
   t.equal(rectsDefined, rectsIsNext);
+
+  t.end();
+});
+
+tape('lineChunked() with extendEnds set', function (t) {
+  const document = jsdom.jsdom();
+  const g = select(document.body).append('svg').append('g');
+
+  const chunked = lineChunked()
+    .lineAttrs({ 'stroke-width': 0 })
+    .extendEnds([0, 10])
+    .defined(d => d[1] !== null);
+
+  const data = [[1, 2], [2, 1], [3, null], [4, 1], [5, null], [6, 2], [7, 3]];
+
+  g.datum(data).call(chunked);
+  // console.log(g.node().innerHTML);
+
+  t.equal(lengthOfPath(g.select(definedLineClass)), 5);
+  t.equal(lengthOfPath(g.select(undefinedLineClass)), 7);
+  t.equal(g.select(definedPointClass).size(), 1);
+
+  const undefPathPoints = g.select(undefinedLineClass).attr('d').split(/(?=[ML])/);
+  // should move to edge and line to first point
+  t.equal(undefPathPoints[0], 'M0,2');
+  t.equal(undefPathPoints[1], 'L1,2');
+
+  // should line to end point
+  t.equal(undefPathPoints[undefPathPoints.length - 1], 'L10,3');
+
+  const rects = g.selectAll('clipPath').selectAll('rect');
+  t.equal(3, rects.size(), 3);
+  t.deepEqual({ x: '1', width: '1', y: '1', height: '2' }, rectDimensions(rects.nodes()[0]));
+  t.deepEqual({ x: '4', width: '0', y: '1', height: '2' }, rectDimensions(rects.nodes()[1]));
+  t.deepEqual({ x: '6', width: '1', y: '1', height: '2' }, rectDimensions(rects.nodes()[2]));
 
   t.end();
 });


### PR DESCRIPTION
By passing in the range of potential x values to lineChunked by calling `.extendEnds([xMin, xMax])` (e.g. `.extendEnds(xScale.range())`), the undefined line will extend to the edges. It uses the y value from the closest defined point.

Before:
![image](https://cloud.githubusercontent.com/assets/793847/18038258/b1065c38-6d63-11e6-83d0-769b15255486.png)

After:
![image](https://cloud.githubusercontent.com/assets/793847/18038284/fef0f9b2-6d63-11e6-8a4b-cf1ce249c5e8.png)

Looks kind of dorky with a dashed line as the undefined line at such thick stroke widths, but it works and looks fine at other settings.