### PR TITLE
When extending ends, also extend the defined line.

### DIFF
--- a/test/lineChunked-test.js
+++ b/test/lineChunked-test.js
@@ -243,7 +243,7 @@ tape('lineChunked() with extendEnds set', function (t) {
   g.datum(data).call(chunked);
   // console.log(g.node().innerHTML);
 
-  t.equal(lengthOfPath(g.select(definedLineClass)), 5);
+  t.equal(lengthOfPath(g.select(definedLineClass)), 7);
   t.equal(lengthOfPath(g.select(undefinedLineClass)), 7);
   t.equal(g.select(definedPointClass).size(), 1);
 


### PR DESCRIPTION
This resolves #6 by making sure the undefined line and the defined line always draw the same thing. The extended ends are simply hidden by the clip rectangles, just like usual.