### PR TITLE
Support styled chunks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     "browser": true
   },
   "rules": {
+    "max-len": [1, 120, { "ignoreComments": true, "ignoreTrailingComments": true, "ignoreUrls": true }],
     "no-shadow": 0,
     "no-param-reassign": 0,
     "no-console": 0,

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/d3-line-chunked.svg)](https://badge.fury.io/js/d3-line-chunked)
 
-A d3 plugin that renders a line with potential gaps in the data by styling the gaps differently
-from the defined areas. Single points are rendered as circles. Transitions are supported.
+A d3 plugin that renders a line with potential gaps in the data by styling the gaps differently from the defined areas. It also provides the ability to style arbitrary chunks of the defined data differently. Single points are rendered as circles and transitions are supported.
 
 Blog: [Showing Missing Data in Line Charts](https://bocoup.com/weblog/showing-missing-data-in-line-charts)
 
@@ -168,6 +167,49 @@ function isNext(previousDatum, currentDatum) {
 It is only necessary to define this if your data doesn't explicitly include gaps in it.
 
 The default returns `true` for all points.
+
+
+
+
+
+
+<a href="#lineChunked_chunk" name="lineChunked_chunk">#</a> *lineChunked*.**chunk**([*chunk*])
+
+Get or set *chunk*, a function that given a data point (`d`) returns the name of the chunk it belongs to. This is necessary if you want to have multiple styled chunks of the defined data. There are two reserved chunk names: `"line"` for the default line for defined data, and `"gap"` for undefined data. It is not recommended that you use `"gap"` in this function. The default value maps all data points to `"line"`.
+
+For example, if you wanted all points with y values less than 10 to be in the `"below-threshold"` chunk, you could do the following:
+
+```js
+// sample data
+var data = [{ x: 1, y: 5 }, { x: 2, y: 8 }, { x: 3, y: 12 }, { x: 4, y: 15 }, { x: 5, y: 6 }];
+
+// inspects the y value to determine which chunk to use.
+function chunk(d) {
+  return d.y < 10 ? 'below-threshold' : 'line';
+}
+```
+
+
+<a href="#lineChunked_chunkLineResolver" name="lineChunked_chunkLineResolver">#</a> *lineChunked*.**chunkLineResolver**([*chunkLineResolver*])
+
+Get or set *chunkLineResolver*, a function that decides what chunk the line should be rendered in when given two adjacent defined points that may or may not be in the same chunk via `chunk()`. The function takes three parameters:
+
+  * chunkNameLeft (*String*): The name of the chunk for the point on the left
+  * chunkNameRight (*String*): The name of the chunk for the point on the right
+  * chunkNames (*String[]*): The ordered list of chunk names from chunkDefinitions
+
+It returns the name of the chunk that the line segment should be rendered in. By default it uses the order of the keys in the chunkDefinition object..
+
+For example, if you wanted all lines between two different chunks to use the styling of the chunk that the left point belongs to, you could define *chunkLineResolver* as follows:
+
+```js
+// always take the chunk of the item on the left
+function chunkLineResolver(chunkNameA, chunkNameB, chunkNames) {
+  return chunkNameA;
+}
+```
+
+
 
 
 

--- a/example/example-gallery.js
+++ b/example/example-gallery.js
@@ -217,6 +217,77 @@
       },
     },
     {
+      label: 'Different styled chunks',
+      render: function typicalExample(root) {
+        var g = root.append('svg')
+          .attr('width', exampleWidth)
+          .attr('height', exampleHeight)
+          .append('g');
+
+        var chunked = d3.lineChunked()
+          .x(function (d) { return x(d[0]); })
+          .y(function (d) { return y(d[1]); })
+          .defined(function (d) { return d[1] !== null; })
+          .chunkDefinitions({
+            line: {
+              styles: {
+                stroke: '#0bb',
+              },
+            },
+            gap: {
+              styles: {
+                stroke: 'none'
+              }
+            },
+            chunk1: {
+              styles: {
+                'stroke-dasharray': '2, 2',
+                'stroke-opacity': 0.35,
+              },
+              pointStyles: {
+                'fill': '#fff',
+                'stroke': '#0bb',
+              }
+            }
+          })
+          .chunk(function (d) { return d[1] > 1 ? 'chunk1' : 'line'; });
+
+        var data = [[0, 2], [1, 1], [2, 2], [3, null], [3.5, 1], [4, 0.8], [4.5, null], [5, 1], [6, 2], [7, 1], [7.5, 1], [8, null], [9, 2], [10, null]];
+
+        g.datum(data).call(chunked);
+      },
+    },
+    {
+      label: 'Different styled chunks 2',
+      render: function typicalExample(root) {
+        var g = root.append('svg')
+          .attr('width', exampleWidth)
+          .attr('height', exampleHeight)
+          .append('g');
+
+        const chunked = d3.lineChunked()
+          .x(function (d) { return x(d[0]); })
+          .y(function (d) { return y(d[1]); })
+          .defined(function (d) { return d[1] !== null; })
+          .chunkDefinitions({
+            line: {
+              styles: { stroke: 'red' },
+            },
+            gap: {
+              styles: { stroke: 'silver' },
+            },
+            chunk1: {
+              styles: { stroke: 'blue' },
+            },
+          })
+          .chunk(function (d) { return d[1] > 1 ? 'chunk1' : 'line'; });
+
+        const data = [[0, 2], [1, 1], [2, 2], [3, null], [4, 1], [5, 2], [6, 1], [7, 1], [8, null], [9, 2], [10, null]];
+
+        g.datum(data).call(chunked);
+      },
+    },
+    {
       label: 'Transition: transitionInitial=true',
       transition: true,
       render: function transitionInitialTrue(root) {

--- a/example/example.css
+++ b/example/example.css
@@ -17,3 +17,16 @@ body {
 .description {
   max-width: 800px;
 }
+
+.example-gallery .example {
+  display: inline-block;
+  margin-right: 15px;
+  margin-bottom: 15px;
+  border: 1px dotted #ccc;
+  padding: 10px;
+  vertical-align: top;
+}
+
+.example h3 {
+  margin-top: 0;
+}

--- a/example/index.html
+++ b/example/index.html
@@ -4,13 +4,6 @@
     <title>d3-line-chunked</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="example.css" />
-    <style>
-      .example-gallery .example {
-        display: inline-block;
-        margin-right: 15px;
-        margin-bottom: 15px;
-      }
-    </style>
   </head>
   <body>
     <h1 class="main-header">d3-line-chunked</h1>

--- a/src/lineChunked.js
+++ b/src/lineChunked.js
@@ -869,6 +869,9 @@ export default function () {
           yExtent, evaluatedDefinition, path, clipPathId);
       }
     });
+
+    // ensure all circles are at the top
+    root.selectAll('circle').raise();
   }
 
   // the main function that is returned

--- a/src/lineChunked.js
+++ b/src/lineChunked.js
@@ -182,6 +182,28 @@ export default function () {
 
 
   /**
+   * Logs warnings if the chunk definitions uses 'style' or 'attr' instead of
+   * 'styles' or 'attrs'
+   */
+  function validateChunkDefinitions() {
+    Object.keys(chunkDefinitions).forEach(key => {
+      const def = chunkDefinitions[key];
+      if (def.style != null) {
+        console.warn(`Warning: chunkDefinitions expects "styles", but found "style" in ${key}`, def);
+      }
+      if (def.attr != null) {
+        console.warn(`Warning: chunkDefinitions expects "attrs", but found "attr" in ${key}`, def);
+      }
+      if (def.pointStyle != null) {
+        console.warn(`Warning: chunkDefinitions expects "pointStyles", but found "pointStyle" in ${key}`, def);
+      }
+      if (def.pointAttr != null) {
+        console.warn(`Warning: chunkDefinitions expects "pointAttrs", but found "pointAttr" in ${key}`, def);
+      }
+    });
+  }
+
+  /**
    * Helper to get the chunk names that are defined. Prepends
    * line, gap to the start of the array unless useChunkDefOrder
    * is specified. In this case, it only prepends if they are
@@ -896,6 +918,9 @@ export default function () {
       const initialRender = root.select('.d3-line-chunked-defined').empty();
       renderLines(initialRender, transition, context, root, data, lineIndex);
     });
+
+    // provide warning about wrong attr/defs
+    validateChunkDefinitions();
   }
 
   // ------------------------------------------------

--- a/src/lineChunked.js
+++ b/src/lineChunked.js
@@ -662,10 +662,12 @@ export default function () {
       const evaluatedChunk = {
         styles: Object.assign({},
           evaluateAttrsOrStyles(lineStyles),
+          evaluateAttrsOrStyles((chunkDefinitions[lineChunkName] || {}).styles),
           chunkName === gapChunkName ? evaluateAttrsOrStyles(gapStyles) : undefined,
           evaluateAttrsOrStyles(chunkDef.styles)),
         attrs: Object.assign({},
           evaluateAttrsOrStyles(lineAttrs),
+          evaluateAttrsOrStyles((chunkDefinitions[lineChunkName] || {}).attrs),
           chunkName === gapChunkName ? evaluateAttrsOrStyles(gapAttrs) : undefined,
           evaluateAttrsOrStyles(chunkDef.attrs)),
       };

--- a/src/lineChunked.js
+++ b/src/lineChunked.js
@@ -63,6 +63,31 @@ export default function () {
   let isNext = () => true;
 
   /**
+   * Function to determine which chunk this data is within.
+   *
+   * @param {Any} d data point
+   * @param {Any[]} data the full dataset
+   * @return {String} The id of the chunk. Defaults to "line"
+   */
+  let chunk = () => 'line';
+
+  /**
+   * Object specifying how to set style and attributes for each chunk.
+   * Format is an object:
+   *
+   * {
+   *   chunkName1: {
+   *     styles: {},
+   *     attrs: {},
+   *     pointStyles: {},
+   *     pointAttrs: {},
+   *   },
+   *   ...
+   * }
+   */
+  let chunkDefinitions = {};
+
+  /**
    * Passed through to d3.line().curve. Default value: d3.curveLinear.
    */
   let curve = curveLinear;
@@ -711,6 +736,21 @@ export default function () {
     set: (newValue) => { isNext = newValue; },
     setType: 'function',
     asConstant: (newValue) => () => !!newValue,
+  });
+
+  // define `chunk([chunk])`
+  lineChunked.chunk = getterSetter({
+    get: () => chunk,
+    set: (newValue) => { chunk = newValue; },
+    setType: 'function',
+    asConstant: (newValue) => () => newValue,
+  });
+
+  // define `chunkDefinitions([chunkDefinitions])`
+  lineChunked.chunkDefinitions = getterSetter({
+    get: () => chunkDefinitions,
+    set: (newValue) => { chunkDefinitions = newValue; },
+    setType: 'object',
   });
 
   // define `curve([curve])`

--- a/test/lineChunked-test.js
+++ b/test/lineChunked-test.js
@@ -167,6 +167,62 @@ tape('lineChunked() with many data points and some undefined', function (t) {
 });
 
 
+tape('lineChunked() sets attrs and styles', function (t) {
+  const document = jsdom.jsdom();
+  const g = select(document.body).append('svg').append('g');
+
+  const chunked = lineChunked()
+    .lineAttrs({
+      'stroke-width': 4,
+      stroke: (d, i) => i === 0 ? 'blue' : 'red',
+    })
+    .lineStyles({
+      fill: 'purple',
+      stroke: (d, i) => i === 0 ? 'orange' : 'green',
+    })
+    .gapAttrs({
+      'stroke-width': 2,
+      stroke: (d, i) => i === 0 ? 'teal' : 'cyan',
+    })
+    .gapStyles({
+      stroke: (d, i) => i === 0 ? 'magenta' : 'brown',
+    })
+    .pointAttrs({
+      'r': 20,
+    })
+    .pointStyles({
+      fill: 'maroon',
+      stroke: (d, i) => i === 0 ? 'indigo' : 'violet',
+    })
+    .defined(d => d[1] !== null);
+
+  const data = [[0, 1], [1, 2], [2, null], [3, null], [4, 1], [5, null], [6, 2], [7, 3]];
+
+  g.datum(data).call(chunked);
+  // console.log(g.node().innerHTML);
+
+  const line = g.select(definedLineClass);
+  const gap = g.select(undefinedLineClass);
+  const point = g.select('circle');
+
+  t.equal(line.attr('stroke-width'), '4');
+  t.equal(line.attr('stroke'), 'blue');
+  t.equal(line.style('fill'), 'purple');
+  t.equal(line.style('stroke'), 'orange');
+
+  t.equal(gap.attr('stroke-width'), '2');
+  t.equal(gap.attr('stroke'), 'teal');
+  t.equal(gap.style('fill'), 'purple');
+  t.equal(gap.style('stroke'), 'magenta');
+
+  t.equal(point.attr('r'), '20');
+  t.equal(point.attr('fill'), 'blue');
+  t.equal(point.style('fill'), 'maroon');
+  t.equal(point.style('stroke'), 'indigo');
+
+  t.end();
+});
+
 
 tape('lineChunked() stroke width clipping adjustments', function (t) {
   const document = jsdom.jsdom();

--- a/test/lineChunked-test.js
+++ b/test/lineChunked-test.js
@@ -275,7 +275,6 @@ tape('lineChunked() sets attrs and styles via chunkDefinitions', function (t) {
           'r': 20,
         },
         pointStyles: {
-          fill: 'maroon',
           stroke: (d, i) => i === 0 ? 'indigo' : 'violet',
         }
       },
@@ -324,7 +323,7 @@ tape('lineChunked() sets attrs and styles via chunkDefinitions', function (t) {
 
   t.equal(point.attr('r'), '20');
   t.equal(point.attr('fill'), 'blue');
-  t.equal(point.style('fill'), 'maroon');
+  t.equal(point.style('fill'), 'orange');
   t.equal(point.style('stroke'), 'indigo');
 
   t.end();

--- a/test/lineChunked-test.js
+++ b/test/lineChunked-test.js
@@ -43,6 +43,9 @@ tape('lineChunked() getter and setters work', function (t) {
   t.equal(chunked.defined(d => d > 4).defined()(5), true, 'defined sets function');
   t.equal(chunked.isNext(false).isNext()(3), false, 'isNext makes constant function');
   t.equal(chunked.isNext(d => d > 4).isNext()(3), false, 'isNext sets function');
+  t.equal(chunked.chunk('my-chunk').chunk()(9), 'my-chunk', 'chunk makes constant function');
+  t.equal(chunked.chunk(d => d > 4 ? 'foo' : 'bar').chunk()(5), 'foo', 'chunk sets function');
+  t.deepEqual(chunked.chunkDefinitions({ chunk1: { styles: { color: 'red' } } }).chunkDefinitions(), { chunk1: { styles: { color: 'red' } } }, 'chunkDefinitions sets object');
   t.equal(chunked.curve(d => 5).curve()(3), 5, 'curve sets function');
   t.deepEqual(chunked.lineStyles({ fill: 'red' }).lineStyles(), { fill: 'red' }, 'lineStyles sets object');
   t.deepEqual(chunked.lineAttrs({ fill: 'red' }).lineAttrs(), { fill: 'red' }, 'lineAttrs sets object');

--- a/test/lineChunked-test.js
+++ b/test/lineChunked-test.js
@@ -117,7 +117,7 @@ tape('lineChunked() with null transition to null', function (t) {
   const data = [[0, null]];
 
   g.datum(data).call(chunked).transition().call(chunked);
-  console.log(g.node().innerHTML);
+  // console.log(g.node().innerHTML);
 
   t.equal(lengthOfPath(g.select(definedLineClass)), 0);
   t.equal(lengthOfPath(g.select(undefinedLineClass)), 0);
@@ -537,7 +537,7 @@ tape('lineChunked() puts circles above paths when using multiple chunks', functi
     }
   });
 
-  t.equal(lastPathIndex < firstCircleIndex, true, `last path was at ${lastPathIndex} > first circle at ${firstCircleIndex}`);
+  t.equal(lastPathIndex < firstCircleIndex, true, `last path was at ${lastPathIndex}, first circle was at ${firstCircleIndex}`);
 
   t.end();
 });


### PR DESCRIPTION
Adds in support for styling arbitrary chunks of the defined data by adding in these properties:

- `chunk()` takes a data point and returns the chunk name it belongs to
- `chunkDefinitions` one object that defines styles and attrs for all chunk types
- `chunkLineResolver()` determines which chunk a line segment between adjacent points belongs to