### PR TITLE
Fix rollup build

### DIFF
--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,3 +1,13 @@
 {
-    "presets": ["es2015-rollup"]
+    "presets": [
+        [
+            "es2015",
+            {
+               "modules": false
+            }
+        ]
+    ],
+    "plugins": [
+        "external-helpers"
+    ]
 }


### PR DESCRIPTION
Rollup build failed with error:
> resolve failed:  { Error: Cannot find module 'babel-runtime' at Function.Module._resolveFilename (module.js:527:15)

Fixed it using:
https://github.com/rollup/rollup-plugin-babel/issues/106#issuecomment-266561597